### PR TITLE
[wiki] add a missing parenthesis in two examples

### DIFF
--- a/src/scriptlets/prevent-window-open.js
+++ b/src/scriptlets/prevent-window-open.js
@@ -70,7 +70,7 @@ import {
  * - `replacement` - optional, string to return prop value or property instead of window.open; defaults to return noopFunc.
  * **Examples**
  * ```
- *     example.org#%#//scriptlet('prevent-window-open', '1', '/example\./'
+ *     example.org#%#//scriptlet('prevent-window-open', '1', '/example\./')
  *     example.org#%#//scriptlet('prevent-window-open', '0', 'example')
  *     example.org#%#//scriptlet('prevent-window-open', '', '', 'trueFunc')
  *     example.org#%#//scriptlet('prevent-window-open', '1', '', '{propName=noopFunc}')

--- a/src/scriptlets/set-cookie.js
+++ b/src/scriptlets/set-cookie.js
@@ -24,7 +24,7 @@ import { hit, nativeIsNaN, prepareCookie } from '../helpers';
  *
  * **Examples**
  * ```
- * example.org#%#//scriptlet('set-cookie', 'ReadlyCookieConsent', '1'
+ * example.org#%#//scriptlet('set-cookie', 'ReadlyCookieConsent', '1')
  *
  * example.org#%#//scriptlet('set-cookie', 'gdpr-settings-cookie', 'true')
  * ```

--- a/wiki/about-scriptlets.md
+++ b/wiki/about-scriptlets.md
@@ -1022,7 +1022,7 @@ Old syntax of prevent-window-open parameters:
 - `replacement` - optional, string to return prop value or property instead of window.open; defaults to return noopFunc.
 **Examples**
 ```
-    example.org#%#//scriptlet('prevent-window-open', '1', '/example\./'
+    example.org#%#//scriptlet('prevent-window-open', '1', '/example\./')
     example.org#%#//scriptlet('prevent-window-open', '0', 'example')
     example.org#%#//scriptlet('prevent-window-open', '', '', 'trueFunc')
     example.org#%#//scriptlet('prevent-window-open', '1', '', '{propName=noopFunc}')
@@ -1310,7 +1310,7 @@ example.org#%#//scriptlet('set-cookie', name, value)
 
 **Examples**
 ```
-example.org#%#//scriptlet('set-cookie', 'ReadlyCookieConsent', '1'
+example.org#%#//scriptlet('set-cookie', 'ReadlyCookieConsent', '1')
 
 example.org#%#//scriptlet('set-cookie', 'gdpr-settings-cookie', 'true')
 ```


### PR DESCRIPTION
### This PR:

- adds a missing parenthesis in the examples of the following two scriptlets:

  - `prevent-window-open` and
  - `set-cookie`.