### PR TITLE
fix compatibility table entry for `naver-wcslog`

### DIFF
--- a/scripts/compatibility-table.json
+++ b/scripts/compatibility-table.json
@@ -68,9 +68,6 @@
             "adg": "log-on-stack-trace"
         },
         {
-            "adg": "naver-wcslog"
-        },
-        {
             "adg": "noeval"
         },
         {
@@ -308,6 +305,9 @@
         },
         {
             "adg": "metrika-yandex-tag"
+        },
+        {
+            "adg": "naver-wcslog"
         },
         {
             "adg": "noeval",

--- a/wiki/compatibility-table.md
+++ b/wiki/compatibility-table.md
@@ -19,7 +19,6 @@
 | [log-addEventListener](../wiki/about-scriptlets.md#log-addEventListener) | addEventListener-logger.js (aell.js) |  |
 | [log-eval](../wiki/about-scriptlets.md#log-eval) |  |  |
 | [log-on-stack-trace](../wiki/about-scriptlets.md#log-on-stack-trace) |  |  |
-| [naver-wcslog](../wiki/about-scriptlets.md#naver-wcslog) |  |  |
 | [noeval](../wiki/about-scriptlets.md#noeval) |  |  |
 | [nowebrtc](../wiki/about-scriptlets.md#nowebrtc) | nowebrtc.js |  |
 | [no-topics](../wiki/about-scriptlets.md#no-topics) |  |  |
@@ -95,6 +94,7 @@
 | [matomo](../wiki/about-redirects.md#matomo) |  |  |
 | [metrika-yandex-watch](../wiki/about-redirects.md#metrika-yandex-watch) |  |  |
 | [metrika-yandex-tag](../wiki/about-redirects.md#metrika-yandex-tag) |  |  |
+| [naver-wcslog](../wiki/about-redirects.md#naver-wcslog) |  |  |
 | [noeval](../wiki/about-redirects.md#noeval) | noeval-silent.js |  |
 | [noopcss](../wiki/about-redirects.md#noopcss) |  | blank-css |
 | [noopframe](../wiki/about-redirects.md#noopframe) | noop.html | blank-html |


### PR DESCRIPTION
:heavy_check_mark: Fixes compatibility table entry for `naver-wcslog`.
&nbsp;
**From:**
&nbsp;&nbsp;&nbsp; _Scriptlets compatibility table_ section with link `../wiki/about-scriptlets.md#naver-wcslog`

**To:**
&nbsp;&nbsp;&nbsp; _Redirects compatibility table_ section with link `../wiki/about-redirects.md#naver-wcslog`.
&nbsp;
&nbsp;