### PR TITLE
Fix #223 prevent-refresh

### DIFF
--- a/src/scriptlets/prevent-refresh.js
+++ b/src/scriptlets/prevent-refresh.js
@@ -71,6 +71,9 @@ export function preventRefresh(source, delaySec) {
                 return contentDelay;
             })
             .filter((delay) => delay !== null);
+        // Check if "delays" array is empty, may happens when meta's content is invalid
+        // and reduce() method cannot be used with empty arrays without initial value
+        if (!delays.length) { return; }
         // Get smallest delay of all metas on the page
         const minDelay = delays.reduce((a, b) => Math.min(a, b));
         // eslint-disable-next-line consistent-return
@@ -84,11 +87,11 @@ export function preventRefresh(source, delaySec) {
         }
         let secondsToRun = getNumberFromString(delaySec);
         // Check if argument is provided
-        if (!secondsToRun) {
+        if (secondsToRun == null) {
             secondsToRun = getMetaContentDelay(metaElements);
         }
         // Check if meta tag has delay
-        if (!secondsToRun) {
+        if (secondsToRun == null) {
             return;
         }
         const delayMs = secondsToRun * 1000;

--- a/src/scriptlets/prevent-refresh.js
+++ b/src/scriptlets/prevent-refresh.js
@@ -73,7 +73,9 @@ export function preventRefresh(source, delaySec) {
             .filter((delay) => delay !== null);
         // Check if "delays" array is empty, may happens when meta's content is invalid
         // and reduce() method cannot be used with empty arrays without initial value
-        if (!delays.length) { return; }
+        if (!delays.length) {
+            return null;
+        }
         // Get smallest delay of all metas on the page
         const minDelay = delays.reduce((a, b) => Math.min(a, b));
         // eslint-disable-next-line consistent-return
@@ -87,11 +89,11 @@ export function preventRefresh(source, delaySec) {
         }
         let secondsToRun = getNumberFromString(delaySec);
         // Check if argument is provided
-        if (secondsToRun == null) {
+        if (secondsToRun === null) {
             secondsToRun = getMetaContentDelay(metaElements);
         }
         // Check if meta tag has delay
-        if (secondsToRun == null) {
+        if (secondsToRun === null) {
             return;
         }
         const delayMs = secondsToRun * 1000;

--- a/tests/scriptlets/prevent-refresh.test.js
+++ b/tests/scriptlets/prevent-refresh.test.js
@@ -115,6 +115,7 @@ test('Prevent redirect, in case of invalid content, checks for - TypeError: Redu
     const done = assert.async();
     setTimeout(() => {
         assert.ok(testPassed, 'No error');
+        assert.strictEqual(window.hit, undefined, 'should not hit');
         removeMeta();
         done();
     }, 1 * 1000);

--- a/tests/scriptlets/prevent-refresh.test.js
+++ b/tests/scriptlets/prevent-refresh.test.js
@@ -99,10 +99,8 @@ test('Prevent redirect, in case of invalid content, checks for - TypeError: Redu
     // Check if there is a "Reduce of empty array with no initial value" error in console
     // if so, then set "testPassed" to "false"
     const checkConsole = () => {
-        const logMessages = [];
         const wrapperLog = (target, thisArg, args) => {
-            logMessages.push(...args);
-            if (logMessages[0]?.message?.includes('Reduce of empty array with no initial value')) {
+            if (args[0]?.message?.includes('Reduce of empty array with no initial value')) {
                 testPassed = false;
             }
             return Reflect.apply(target, thisArg, args);


### PR DESCRIPTION
Issue - https://github.com/AdguardTeam/Scriptlets/issues/223

Fixes issue with not working scriptlet if "content" has 0 seconds delay (changed `!secondsToRun` to `secondsToRun == null`).

I have added also:
```js
if (!delays.length) { return; }
```
to `getMetaContentDelay` function to fix error - `TypeError: Reduce of empty array with no initial value`, in case if there is invalid meta's content. This error is visible only in console as scriptlets run in `try...catch`, but I thought that it may be worth to fix.

Added `removeMeta` function, to remove `meta` element when test is done.

Modified `REL_PAGE_PATH` to fix issue error `'../scriptlets/test-files/empty.html' causes ENOENT: no such file or directory` when redirection is not prevented after running `yarn test`.