### PR TITLE
Fix prevent-xhr — blob response #206

### DIFF
--- a/src/scriptlets/prevent-xhr.js
+++ b/src/scriptlets/prevent-xhr.js
@@ -79,6 +79,7 @@ export function preventXHR(source, propsToMatch, randomize) {
     }
 
     let shouldPrevent = false;
+    let response = '';
     let responseText = '';
     let responseUrl;
     const openWrapper = (target, thisArg, args) => {
@@ -121,6 +122,10 @@ export function preventXHR(source, propsToMatch, randomize) {
             return Reflect.apply(target, thisArg, args);
         }
 
+        if (thisArg.responseType === 'blob') {
+            response = new Blob();
+        }
+
         if (randomize === 'true') {
             // Generate random alphanumeric string of 10 symbols
             responseText = Math.random().toString(36).slice(-10);
@@ -128,7 +133,7 @@ export function preventXHR(source, propsToMatch, randomize) {
         // Mock response object
         Object.defineProperties(thisArg, {
             readyState: { value: 4, writable: false },
-            response: { value: '', writable: false },
+            response: { value: response, writable: false },
             responseText: { value: responseText, writable: false },
             responseURL: { value: responseUrl, writable: false },
             responseXML: { value: '', writable: false },

--- a/tests/scriptlets/prevent-xhr.test.js
+++ b/tests/scriptlets/prevent-xhr.test.js
@@ -221,6 +221,36 @@ if (isSupported) {
         };
         xhr.send();
     });
+
+    test('Args, prevent matched - blob', async (assert) => {
+        const createImg = document.createElement('img');
+        const METHOD = 'GET';
+        const URL = `${FETCH_OBJECTS_PATH}/test-image.jpeg`;
+        const MATCH_DATA = [`test-image.jpeg method:${METHOD}`];
+
+        runScriptlet(name, MATCH_DATA);
+
+        const done = assert.async();
+
+        const xhr = new XMLHttpRequest();
+        xhr.open(METHOD, URL);
+        xhr.responseType = 'blob';
+        xhr.onload = () => {
+            try {
+                createImg.setAttribute('src', window.URL.createObjectURL(xhr.response));
+            } catch (error) {
+                console.error(error);
+            }
+            document.body.appendChild(createImg);
+            assert.strictEqual(xhr.readyState, 4, 'Response done');
+            assert.strictEqual(xhr.response instanceof Blob, true, 'Response data mocked');
+            assert.ok(createImg.src.startsWith('blob:'), 'Image with source blob');
+            assert.strictEqual(window.hit, 'FIRED', 'hit function fired');
+            createImg.remove();
+            done();
+        };
+        xhr.send();
+    });
 } else {
     test('unsupported', (assert) => {
         assert.ok(true, 'Browser does not support it');


### PR DESCRIPTION
Fixes issue with `responseType` `blob` - https://github.com/AdguardTeam/Scriptlets/issues/206#issue-1196386338

I have added tasks to this issue - https://github.com/AdguardTeam/Scriptlets/issues/206 (the same for - https://github.com/AdguardTeam/Scriptlets/issues/216) and I hope that you don't mind if it will be fixed in few separated pull requests.