### PR TITLE
Relax agtree version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "neverBuiltDependencies": []
     },
     "dependencies": {
-        "@adguard/agtree": "3.2.0",
+        "@adguard/agtree": "^3.2.0",
         "@types/trusted-types": "^2.0.7",
         "js-yaml": "^3.14.1"
     },


### PR DESCRIPTION
Prevent multiple versions of `agtree` when `scriptlets` are used along `tsurlfilter`.

Current version of `tsurlfilter` requires `agtree@3.2.1` but scritplets need `agtree@3.2.0`