### PR TITLE
Security: Unsafe redirect name lookup via inherited properties

### DIFF
--- a/scripts/build-redirects-map.js
+++ b/scripts/build-redirects-map.js
@@ -10,7 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const createRedirectsMap = (redirects) => {
-    const map = {};
+    const map = Object.create(null);
 
     redirects.forEach((item) => {
         const { title, aliases, file } = item;

--- a/src/redirects/index.js
+++ b/src/redirects/index.js
@@ -8,7 +8,9 @@ import { redirectsMap } from '../../tmp/redirects-map';
  * @returns {string} — Redirect's filename with extension
  */
 const getRedirectFilename = (name) => {
-    return redirectsMap[name];
+    return Object.prototype.hasOwnProperty.call(redirectsMap, name)
+        ? redirectsMap[name]
+        : undefined;
 };
 
 export {


### PR DESCRIPTION
## Summary

Security: Unsafe redirect name lookup via inherited properties

## Problem

**Severity**: `Low` | **File**: `src/redirects/index.js:L9`

`getRedirectFilename` returns `redirectsMap[name]` directly with no own-property check. If `name` is attacker-controlled, special property names (e.g., `toString`, `__proto__`) may resolve inherited values instead of valid redirect filenames, causing type confusion and unsafe downstream behavior.

## Solution

Use an own-property guard: `Object.prototype.hasOwnProperty.call(redirectsMap, name) ? redirectsMap[name] : undefined`. Prefer a null-prototype map for `redirectsMap` generation.

## Changes

- `src/redirects/index.js` (modified)
- `scripts/build-redirects-map.js` (modified)